### PR TITLE
Added Pixel 10 Pro XL aka mustang

### DIFF
--- a/.github/workflows/release-multiple.yaml
+++ b/.github/workflows/release-multiple.yaml
@@ -23,6 +23,8 @@ jobs:
         include:
           - device-id: tangorpro # Pixel Tablet
             magisk-preinit-device: sda5
+          - device-id: mustang # Pixel 10 Pro XL
+            magisk-preinit-device: sda10
           - device-id: tegu # Pixel 9a
             magisk-preinit-device: sda10
           - device-id: komodo # Pixel 9 Pro XL


### PR DESCRIPTION
Magisk confirmed that the preinit device on Pixel 10 Pro XL is still sda10, the same as on Pixel 9 Pro XL.